### PR TITLE
fix(ci): Don't follow web links by default (check, serve)

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -19,4 +19,4 @@ enable = false
 [output.linkcheck]
 # Should we check links on the internet? Enabling this option adds a
 # non-negligible performance impact
-follow-web-links = true
+follow-web-links = false

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,14 @@
                 mdbook build
               '';
             };
+            deepcheck.program = pkgs.writeShellApplication {
+              name = "deepcheck";
+              runtimeInputs = treefmtRuntimeInputs ++ mdbookRuntimeInputs;
+              text = ''
+                treefmt --no-cache --fail-on-change
+                MDBOOK_OUTPUT__LINKCHECK__follow_web_links=true mdbook build
+              '';
+            };
           };
           formatter = pkgs.writeShellApplication {
             name = "treefmt";


### PR DESCRIPTION
When running `nix run .#check` or `nix run .#serve`, don't linkcheck external links.

The reason is that several of HashiCorp's resources that we link to serve 429s that are supposed to mean Too Many Requests, but they serve them 100% of the time to our linkchecker.

Instead, run `nix run .#deepcheck` to follow web links.

See #21.