### PR TITLE
docs: Fix documentation navigation and flakes tutorial

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -23,6 +23,7 @@ enable = false
 follow-web-links = false
 
 [output.html.redirect]
+# Redirecting because of brokenness when using subdirectories
 "documentation/flakes.html" = "../flakes.html"
 "documentation/functions.html" = "../functions.html"
 "documentation/getting-started.html" = "../getting-started.html"
@@ -43,3 +44,6 @@ follow-web-links = false
 "news/2023-09-22_release-2.7.0.html" = "../news-2023-09-22_release-2.7.0.html"
 "news/2024-10-15_release-2.8.0.html" = "../news-2024-10-15_release-2.8.0.html"
 "news/2025-11-09_website_renewal.html" = "../news-2025-11-09_website_renewal.html"
+
+# Redirecting because of typos and restructuring
+"getting-startet-with-nix-flakes.html" = "getting-started-with-flakes.html"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -3,10 +3,10 @@
 # Documentation
 
 - [Introduction](index.md)
-- [Getting Started](getting-started.md)
+- [Getting started](getting-started.md)
   - [What is Terraform / OpenTofu?](what-is-terranix.md)
-  - [Getting Started with nix flake](getting-startet-with-nix-flakes.md)
-- [Differences between terranix and HCL](terranix-vs-hcl.md)
+  - [Getting started with flakes](getting-started-with-flakes.md)
+  - [Differences between terranix and HCL](terranix-vs-hcl.md)
 - [Functions](functions.md)
 - [Modules](modules.md)
 - [terranix via nix flakes](flakes.md)

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Getting started
 
 Let's have a quick overview on how you could use terranix.
 


### PR DESCRIPTION
- Fix typo in URL (startet -> started)
- Change casing in heading (Started -> started)
- Add redirect for old typo filename to avoid broken links
- Improve flakes tutorial slightly with example and references